### PR TITLE
Enable Python reserved names in Action attributes

### DIFF
--- a/launch_frontend_py/actions.py
+++ b/launch_frontend_py/actions.py
@@ -12,18 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import builtins
-import keyword
 from typing import Any, Callable
 
 from .entity import Entity
+from .util import is_reserved_identifier
 
 __all__ = []
-
-
-def is_reserved_identifier(name: str) -> bool:
-    """Check if a name is a reserved identifier in Python."""
-    return keyword.iskeyword(name) or name in dir(builtins)
 
 
 def _make_action_factory(action_name: str) -> Callable[..., Any]:

--- a/launch_frontend_py/actions.py
+++ b/launch_frontend_py/actions.py
@@ -12,15 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import builtins
+import keyword
 from typing import Any, Callable
 
-from .entity import Entity, is_reserved_identifier
+from .entity import Entity
 
 __all__ = []
 
 
-def make_action_factory(action_name: str, **kwargs) -> Callable[..., Any]:
-    # Create a factory function for each action entity
+def is_reserved_identifier(name: str) -> bool:
+    """Check if a name is a reserved identifier in Python."""
+    return keyword.iskeyword(name) or name in dir(builtins)
+
+
+def _make_action_factory(action_name: str) -> Callable[..., Any]:
+    """Create a factory function that constructs an Entity of the given action type."""
     if is_reserved_identifier(action_name):
         action_name += '_'
 
@@ -36,15 +43,25 @@ def make_action_factory(action_name: str, **kwargs) -> Callable[..., Any]:
     return fn
 
 
-def preseed_all_actions() -> None:
-    """Pre-seed all actions in the module."""
+def _preseed_all_actions() -> None:
+    """
+    Pre-seed all available actions into this module.
+
+    This is called at module load time, but will not have access to actions from plugin packages
+    (such as launch_ros) until they have been imported into the Python process.
+    """
     from launch.frontend.expose import action_parse_methods
 
     for action_name in action_parse_methods.keys():
-        make_action_factory(action_name)
+        _make_action_factory(action_name)
 
 
 def __getattr__(name: str) -> Any:
+    """
+    Dynamically create action factory functions on demand.
+
+    This is called when user `from launch_frontend_py.actions import <name>`.
+    """
     from launch.frontend.expose import action_parse_methods
     import importlib
 
@@ -55,7 +72,7 @@ def __getattr__(name: str) -> Any:
     # If not, perhaps it was exposed later or not accessed yet
     base_name = name[:-1] if name.endswith('_') else name
     if base_name in action_parse_methods:
-        return make_action_factory(name)
+        return _make_action_factory(name)
     else:
         msg = f'module {__name__} has no attribute "{name}"'
         if base_name != name:
@@ -63,4 +80,4 @@ def __getattr__(name: str) -> Any:
         raise AttributeError(msg)
 
 
-preseed_all_actions()
+_preseed_all_actions()

--- a/launch_frontend_py/entity.py
+++ b/launch_frontend_py/entity.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 
 """Module for launch_frontend_py Entity class."""
-import builtins
 from collections.abc import Iterable
-import keyword
 from typing import (
     List,
     Optional,
@@ -31,11 +29,6 @@ from launch.utilities.type_utils import (
     AllowedValueType,
     is_instance_of,
 )
-
-
-def is_reserved_identifier(name: str) -> bool:
-    """Check if a name is a reserved identifier in Python."""
-    return keyword.iskeyword(name) or name in dir(builtins)
 
 
 class Entity(BaseEntity):

--- a/launch_frontend_py/entity.py
+++ b/launch_frontend_py/entity.py
@@ -30,6 +30,8 @@ from launch.utilities.type_utils import (
     is_instance_of,
 )
 
+from .util import is_reserved_identifier
+
 
 class Entity(BaseEntity):
     """Single item in the intermediate front_end representation."""
@@ -106,6 +108,10 @@ class Entity(BaseEntity):
         See :py:meth:`launch.frontend.Entity.get_attr`.
         Does not apply type coercion, only checks if the read value is of the correct type.
         """
+        # Reserved identifiers are all suffixed with an underscore
+        if is_reserved_identifier(name):
+            name += '_'
+
         if name not in self.__attrs:
             if not optional:
                 raise AttributeError(

--- a/launch_frontend_py/util.py
+++ b/launch_frontend_py/util.py
@@ -12,15 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from launch_frontend_py import launch
-from launch_frontend_py.actions import arg, executable
+import builtins
+import keyword
 
 
-def generate_launch_description():
-    return launch([
-        arg(name='message', default='hello world'),
-        arg(name='condition', default='True'),
-        executable(cmd='echo $(var message)', output='both'),
-        executable(cmd='echo hello conditional', if_='$(var condition)', output='both'),
-        executable(cmd='echo hello not-condition', if_='$(not $(var condition))', output='both'),
-    ])
+def is_reserved_identifier(name: str) -> bool:
+    """
+    Check if a name is a reserved identifier in Python.
+
+    Used to avoid naming issues in the launch DSL that overlap with Python reserved words.
+    """
+    return keyword.iskeyword(name) or name in dir(builtins)

--- a/test/launch/basic_launch.py
+++ b/test/launch/basic_launch.py
@@ -20,4 +20,5 @@ def generate_launch_description():
     return launch([
         arg(name='message', default='hello world'),
         executable(cmd='echo $(var message)', output='both'),
+        # executable(cmd='echo conditional', if_=True),
     ])


### PR DESCRIPTION
Closes #6 

This enables the `condition` attribute of the base Action class, which is `if` in YAML/XML, but that's a Python language keyword.

To handle this generally, instead suffix any reserved word with `_`, so it looks like

```
executable(cmd='echo hello', if_='True')
``` 